### PR TITLE
Rename of BasicRemoteExecutionManager and other small fixes

### DIFF
--- a/brem/ui/RemoteFileDialog.py
+++ b/brem/ui/RemoteFileDialog.py
@@ -111,7 +111,7 @@ class RemoteFileDialog(QtWidgets.QDialog):
     def setupConnection(self, logfile=None, port=None, host=None, \
             username=None, private_key=None, remote_os=None):
         
-        a = brem.RemoteExecutionManager(logfile=logfile, 
+        a = brem.BasicRemoteExecutionManager(logfile=logfile, 
                                         port=port, 
                                         host=host, 
                                         username=username, 
@@ -343,7 +343,7 @@ class RemoteFileDialog(QtWidgets.QDialog):
         remote_os = kwargs.get('remote_os')
         
         logfile = 'logfile.log'
-        conn = brem.RemoteExecutionManager(logfile=logfile,
+        conn = brem.BasicRemoteExecutionManager(logfile=logfile,
                                            port=port, 
                                            host=host, 
                                            username=username,

--- a/brem/ui/RemoteServerSettingDialog.py
+++ b/brem/ui/RemoteServerSettingDialog.py
@@ -415,18 +415,20 @@ class GenerateKeygenDialog(QtWidgets.QDialog):
         if mask is not None:
             # self.formWidget.widgets['private_key_field'].setText(os.path.abspath(mask))
             self.key_file = mask
+
     def setInfo(self, text):
         '''Writes in the top QLabel information for the user'''
         self.infolabel.setText(text)
 
-    def authorize_key_worker(self, host, username, port, 
-                             progress_callback, message_callback, status_callback=None):
-        a = brem.BasicRemoteExecutionManager( logfile='generatekey.log', 
-                                         port=port, 
-                                         host=host, 
-                                         username=username, 
-                                         private_key=None)
-        
+    def authorize_key_worker(self, host, username, port, **kwargs):
+
+        message_callback = kwargs.get('message_callback')
+        a = brem.BasicRemoteExecutionManager(logfile='generatekey.log',
+                                             port=port,
+                                             host=host,
+                                             username=username,
+                                             private_key=None)
+
         a.login_pw(self.formWidget.widgets['server_password_field'].text())
         message_callback.emit("Generating Key...")
         a.generate_keys(filename=self.key_file)

--- a/brem/ui/RemoteServerSettingDialog.py
+++ b/brem/ui/RemoteServerSettingDialog.py
@@ -351,7 +351,7 @@ class GenerateKeygenDialog(QtWidgets.QDialog):
         qwidget.setClearButtonEnabled(True)
         qwidget.setEchoMode(QtWidgets.QLineEdit.Password)
         # finally add to the form widget
-        fw.addWidget('server_password', qlabel, qwidget)
+        fw.addWidget(qwidget, qlabel, 'server_password')
 
         # insert a QLabel at the top to describe what's happening
         self.infolabel = QtWidgets.QLabel()
@@ -420,8 +420,8 @@ class GenerateKeygenDialog(QtWidgets.QDialog):
         self.infolabel.setText(text)
 
     def authorize_key_worker(self, host, username, port, 
-                             progress_callback, message_callback):
-        a = brem.RemoteExecutionManager( logfile='generatekey.log', 
+                             progress_callback, message_callback, status_callback=None):
+        a = brem.BasicRemoteExecutionManager( logfile='generatekey.log', 
                                          port=port, 
                                          host=host, 
                                          username=username, 


### PR DESCRIPTION
-  RemoteExecutionManager seems to have been renamed to `BasicRemoteExecutionManager` and wasn't updated everywhere
- Some ordering in `addWidget() `was incorrect
- `authorize_key_worker` was receiving a status_callback and not expecting it